### PR TITLE
Fix for OUJS

### DIFF
--- a/tmt.user.js
+++ b/tmt.user.js
@@ -2,6 +2,7 @@
 // @name        toomanytags
 // @namespace   zeratax@firemail.cc
 // @description Copies Tags from other sites (currently only panda)
+// @license     GPL-3.0
 // @include     http://www.tsumino.com/contribute
 // @include     http://tsumino.com/contribute
 // @include     http://pururin.us/contribute/upload


### PR DESCRIPTION
OUJS has made a change recently to require SPDX codes for OSI approved licensing.

In order to improve the appearance of your script homepages it would be appreciated if you could modify all of your affected scripts.

Until this change is made you will be unable to update those affected scripts.

Thanks,
OUJS Staff